### PR TITLE
Remove inactive display-flex property

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -567,7 +567,7 @@
 
         <!-- COMMERCIAL SUPPORT -->
         <div class="al-index-commercial-support al-py-lg">
-            <div class="container display-flex">
+            <div class="container">
                 <h2 class="text-center">
                     {{ i18n "Commercial Support" }}
                 </h2>


### PR DESCRIPTION
Removes the display-flex property because it was not having any effect on the code. The correct property is `d-flex` but that messes up the formatting. 
